### PR TITLE
Mark library classes as final

### DIFF
--- a/src/BinaryReader.php
+++ b/src/BinaryReader.php
@@ -4,7 +4,7 @@ namespace KDuma\BinaryTools;
 
 use RuntimeException;
 
-class BinaryReader
+final class BinaryReader
 {
     private string $_data;
 

--- a/src/BinaryString.php
+++ b/src/BinaryString.php
@@ -2,7 +2,7 @@
 
 namespace KDuma\BinaryTools;
 
-readonly class BinaryString
+final readonly class BinaryString
 {
     protected function __construct(public string $value)
     {

--- a/src/BinaryWriter.php
+++ b/src/BinaryWriter.php
@@ -2,7 +2,7 @@
 
 namespace KDuma\BinaryTools;
 
-class BinaryWriter
+final class BinaryWriter
 {
     private string $buffer = '';
 


### PR DESCRIPTION
## Summary
- mark BinaryReader, BinaryWriter, and BinaryString as final to prevent extension of library classes

## Testing
- composer install *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd2231c7c8332af7d265cc27cc2e2